### PR TITLE
Fix Dockerfile dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache --virtual .build-deps gcc musl-dev \
  && pip install cython \
  && apk del .build-deps
 
-RUN apk add --no-cache libressl-dev musl-dev libffi-dev libpng-dev freetype-dev build-base python-dev py-pip jpeg-dev zlib-dev libxml2-dev
+RUN apk add --no-cache libressl-dev musl-dev libffi-dev libpng-dev freetype-dev build-base python3-dev py3-pip jpeg-dev zlib-dev libxml2-dev
 RUN apk add --update --no-cache g++ gcc libxslt-dev
 
 RUN pip install -r /requirements.txt


### PR DESCRIPTION
`python-dev` no longer a package maintained in Alpine repositories (https://pkgs.alpinelinux.org/packages?name=python*&branch=edge&repo=&arch=x86_64&origin=&flagged=&maintainer=) this PR fixes Docker building to install `python3-dev`.